### PR TITLE
Preparation for deployment

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -14,7 +14,7 @@ services:
       - ./nginx.conf:/etc/nginx/nginx.conf
       - ./ssl/:/etc/nginx/ssl/
     ports:
-      - '443'
+      - '443:443'
     depends_on:
       - spring-backend
     profiles:

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,7 +4,7 @@ http{
     server
     {
         listen 443 ssl;
-        server_name localhost; #TODO: Change to domain name
+        server_name dayguard.dayfit.pl;
 
         ssl_certificate /etc/nginx/ssl/fullchain.pem;
         ssl_certificate_key /etc/nginx/ssl/privkey.pem;


### PR DESCRIPTION
This pull request updates the configuration for the Nginx server to properly handle HTTPS traffic and specify the domain name. The most important changes include binding port 443 to the host and updating the server name in the Nginx configuration.

### Nginx Configuration Updates:

* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cL17-R17): Updated the `ports` section to explicitly map port `443` on the container to port `443` on the host, ensuring proper HTTPS traffic routing.
* [`nginx.conf`](diffhunk://#diff-1f91f64bfa3fb0a1ece881887af0a2356b8c529a96fb91c1894745b2a1a009aaL7-R7): Changed the `server_name` from `localhost` to `dayguard.dayfit.pl`, setting the correct domain name for the server.