### PR TITLE
update application properties and Docker Compose configuration for im…

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,8 +1,8 @@
 services:
   spring-backend:
     build:
-      context: .
-      dockerfile: 'dockerfiles/backend/Dockerfile'
+      context: ../../..
+      dockerfile: '../../../dockerfiles/backend/Dockerfile'
     depends_on:
       - postgres
     profiles:
@@ -49,16 +49,17 @@ services:
       - prod
 
   postgres-dev:
-    image: 'rapidfort/postgresql-official:17.4-alpine3.20'
+    image: postgres:15
     environment:
-      - 'POSTGRES_DB=dayguard'
-      - 'POSTGRES_PASSWORD=secret'
-      - 'POSTGRES_USER=myuser'
+      - POSTGRES_DB=dayguard
+      - POSTGRES_USER=myuser
+      - POSTGRES_PASSWORD=secret
     volumes:
       - ./pgdata-dev:/var/lib/postgresql/data
     ports:
-      - '5432:5432'
+      - "5432:5432"
     labels:
       org.springframework.boot.service-connection: postgres
+      org.springframework.boot.readiness-check.tcp.disable: false
     profiles:
       - dev

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,2 +1,6 @@
-spring.datasource.url=jdbc:postgresql://localhost:5432/dayguard
 allowed.origins=http://localhost:5173
+spring.docker.compose.enabled=true
+spring.docker.compose.file=./compose.yaml
+
+spring.docker.compose.readiness.tcp.connect-timeout=10s
+spring.docker.compose.readiness.tcp.read-timeout=5s

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,3 +1,11 @@
 spring.datasource.url=jdbc:postgresql://postgres:5432/dayguard
 allowed.origins=https://dayguard.dayfit.pl
+spring.rabbitmq.host=rabbitmq
+
 server.forward-headers-strategy=framework
+
+spring.docker.compose.enabled=false
+
+spring.datasource.username=myuser
+spring.datasource.password=secret
+spring.datasource.driver-class-name=org.postgresql.Driver

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,12 +5,7 @@ spring.profiles.active=prod
 logging.level.root=WARN
 logging.level.io.dayfit.github.dayguard.EventListeners=INFO
 
-spring.datasource.username=myuser
-spring.datasource.password=secret
-spring.datasource.driver-class-name=org.postgresql.Driver
-
-spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true
 
 spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
…proved readiness and connection settings

This pull request updates the Docker Compose configuration, modifies application properties for different environments, and improves readiness checks for services. The most important changes include adjustments to the `compose.yaml` file for Docker Compose paths and service configurations, as well as updates to the Spring application properties for better environment-specific settings.

### Docker Compose Configuration Updates:
* Updated `compose.yaml` to adjust the `context` and `dockerfile` paths for the `spring-backend` service, ensuring compatibility with the new directory structure.
* Changed the PostgreSQL image for the `postgres-dev` service from `rapidfort/postgresql-official:17.4-alpine3.20` to `postgres:15` for consistency with production. Added a readiness check label and made minor formatting adjustments.

### Spring Application Properties Updates:
* Added Docker Compose integration settings in `application-dev.properties`, including readiness check timeouts for TCP connections.
* Updated `application-prod.properties` to include RabbitMQ host configuration, disable Docker Compose integration, and specify database credentials and driver.
* Changed `application.properties` to set `spring.jpa.hibernate.ddl-auto` to `validate` instead of `update` for stricter schema validation. Removed database credentials and Hibernate dialect settings, delegating these to environment-specific files.