### PR TITLE
refactor: update Docker Compose and Nginx configuration for improved app deployment

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -24,6 +24,7 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
       - ./ssl/:/etc/nginx/ssl/
+      - /home/deploy/app/:/home/deploy/app:ro
     environment:
       - 'DOMAIN_NAME=${DOMAIN_NAME}'
     ports:

--- a/nginx.conf
+++ b/nginx.conf
@@ -18,8 +18,16 @@ http {
         ssl_certificate /etc/nginx/ssl/fullchain.pem;
         ssl_certificate_key /etc/nginx/ssl/privkey.pem;
 
+        root /home/deploy/app;
+        index index.html;
+
         location / {
-            proxy_pass http://spring-backend:8080;
+            try_files $uri /index.html;
+            limit_req zone=ip_limit burst=20 nodelay;
+        }
+
+        location /api {
+            proxy_pass http://spring-backend:8080/api;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This pull request introduces changes to the Nginx configuration and `compose.yaml` file to enhance the application's deployment setup. The changes include adding a read-only volume for the application, updating the root directory and request handling for static files, and refining the API proxy configuration.

### Deployment setup updates:

* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR27): Added a read-only volume mapping `/home/deploy/app/` from the host to the container to serve application files.

### Nginx configuration updates:

* [`nginx.conf`](diffhunk://#diff-1f91f64bfa3fb0a1ece881887af0a2356b8c529a96fb91c1894745b2a1a009aaR21-R30): Set the root directory to `/home/deploy/app` and specified `index.html` as the default index file.
* [`nginx.conf`](diffhunk://#diff-1f91f64bfa3fb0a1ece881887af0a2356b8c529a96fb91c1894745b2a1a009aaR21-R30): Updated the `/` location block to serve static files directly using `try_files`, falling back to `index.html` if the file is not found. Added a rate-limiting rule to restrict requests from the same IP.
* [`nginx.conf`](diffhunk://#diff-1f91f64bfa3fb0a1ece881887af0a2356b8c529a96fb91c1894745b2a1a009aaR21-R30): Introduced a new `/api` location block to proxy API requests to the backend service at `http://spring-backend:8080/api`.